### PR TITLE
Valid connections are killed when testing idle connections

### DIFF
--- a/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/PooledConnection.java
+++ b/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/PooledConnection.java
@@ -459,6 +459,7 @@ public class PooledConnection {
                     if (!rs.next()) {
                         throw new SQLException("Connection validation failed, no result for query: " + query);
                     }
+                    return true;
 
                 } finally {
                     rs.close();
@@ -469,7 +470,6 @@ public class PooledConnection {
         } catch (SQLException e) {
             return false;
         }
-        return false;
     } //validate
 
     /**


### PR DESCRIPTION
Pool ends up being empty after eviction (not counting busy connections), and valid connections are not re-used
